### PR TITLE
Improve Firebase config validation

### DIFF
--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -10,10 +10,16 @@ const firebaseConfig = {
 let authPromise = null;
 
 if (typeof window !== 'undefined') {
-  authPromise = import('firebase/app')
-    .then(({ initializeApp }) => initializeApp(firebaseConfig))
-    .then((app) => import('firebase/auth'))
-    .then(({ getAuth }) => getAuth(app));
+  const missingConfig = Object.values(firebaseConfig).some((v) => !v);
+  if (missingConfig) {
+    console.error('Firebase config incomplete');
+    authPromise = Promise.reject(new Error('Firebase config incomplete'));
+  } else {
+    authPromise = import('firebase/app')
+      .then(({ initializeApp }) => initializeApp(firebaseConfig))
+      .then((app) => import('firebase/auth'))
+      .then(({ getAuth }) => getAuth(app));
+  }
 }
 
 export const getAuthInstance = () => authPromise;


### PR DESCRIPTION
## Summary
- add environment check before initializing Firebase

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68754af6ffac8332bb86aa6d6ec82cbf

## Summary by Sourcery

Enhancements:
- Validate Firebase configuration before initialization and handle missing values by rejecting the auth promise and logging an error